### PR TITLE
fix: defer flash_attn and sglang imports to avoid ImportError at startup

### DIFF
--- a/kdflow/backend/sglang/sglang_engine.py
+++ b/kdflow/backend/sglang/sglang_engine.py
@@ -9,8 +9,15 @@ from dataclasses import dataclass
 import zmq
 import numpy as np
 import torch
-from sglang.srt.entrypoints.engine import Engine as _SglEngine
-from sglang.srt.managers.scheduler import run_scheduler_process as _original_run_scheduler_process
+
+try:
+    from sglang.srt.entrypoints.engine import Engine as _SglEngine
+    from sglang.srt.managers.scheduler import run_scheduler_process as _original_run_scheduler_process
+    _SGLANG_AVAILABLE = True
+except ModuleNotFoundError:
+    _SglEngine = object
+    _original_run_scheduler_process = None
+    _SGLANG_AVAILABLE = False
 
 
 os.environ["SGLANG_JIT_DEEPGEMM_FAST_WARMUP"] = "true"

--- a/kdflow/models/ring_attn_utils.py
+++ b/kdflow/models/ring_attn_utils.py
@@ -1,7 +1,18 @@
 import torch
 import torch.distributed as dist
-from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
-from flash_attn.utils.distributed import all_gather
+
+
+def _require_flash_attn():
+    """Deferred import — only needed for packing_samples=True."""
+    try:
+        from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
+        from flash_attn.utils.distributed import all_gather as _fa_all_gather
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "flash_attn is required for packing_samples=True. "
+            "Install with: pip install flash_attn --no-build-isolation"
+        ) from e
+    return index_first_axis, pad_input, rearrange, unpad_input, _fa_all_gather
 
 RING_ATTN_GROUP = None
 
@@ -110,7 +121,12 @@ def unpad_and_slice_tensor(sequences, attention_mask, ring_attn_group):
 
     Returns:
         tuple: Processed sequences and related tensors for ring attention
+
+    Note:
+        Requires ``flash_attn`` — only called when ``packing_samples=True``.
     """
+    index_first_axis, pad_input, rearrange, unpad_input, _ = _require_flash_attn()
+
     rolled_sequences = torch.roll(sequences, shifts=-1, dims=1)
     sequences, indices, cu_seqlens, _, _ = unpad_input(sequences.unsqueeze(-1), attention_mask)
     sequences = sequences.transpose(0, 1)  # (1, total_seqs)
@@ -158,9 +174,14 @@ def gather_and_pad_tensor(tensor, ring_attn_group, ring_attn_pad_len, indices, b
 
     Returns:
         Padded tensor
+
+    Note:
+        Requires ``flash_attn`` — only called when ``packing_samples=True``.
     """
+    _, pad_input, _, _, fa_all_gather = _require_flash_attn()
+
     if ring_attn_group is not None:
-        tensor = all_gather(tensor.transpose(0, 1), ring_attn_group).transpose(0, 1)  # (1, total_seqs)
+        tensor = fa_all_gather(tensor.transpose(0, 1), ring_attn_group).transpose(0, 1)  # (1, total_seqs)
         if ring_attn_pad_len > 0:
             tensor = tensor[:, :-ring_attn_pad_len]
     tensor = pad_input(tensor.transpose(0, 1), indices, batch, seqlen).squeeze(-1)  # (batch, seqlen)


### PR DESCRIPTION
## Problem

Two hard dependencies at module import time block basic CLI usage in common environments.

### 1. `flash_attn` — required even when `packing_samples=False`

`ring_attn_utils.py` imports `flash_attn` at the top level, but these functions are only called when `packing_samples=True`. Users who do not use sequence packing — which is the default and most common setup — cannot run `python -m kdflow.cli.train_kd_off_policy --help` or even `import kdflow` if flash_attn is not installed.

This is a real barrier for:
- Python 3.13 (no pre-built wheel exists yet for most CUDA versions)
- Environments with new CUDA versions (e.g. CUDA 12.8, torch 2.9+)
- torch nightly/dev builds

### 2. `sglang` — blocks the CLI even for student-only or argument-inspection use

`sglang_engine.py` imports sglang unconditionally. sglang has a complex install chain (requires Rust for `outlines_core`, specific torch version, etc.) that frequently fails. This prevents the CLI from loading at all.

## Fix

- **`ring_attn_utils.py`**: move flash_attn imports into a `_require_flash_attn()` helper that is called lazily inside `unpad_and_slice_tensor` and `gather_and_pad_tensor`. The error is raised only when these functions are actually invoked (i.e. `packing_samples=True`), with a clear install instruction.

- **`sglang_engine.py`**: wrap sglang imports in `try/except ModuleNotFoundError`; expose `_SGLANG_AVAILABLE` flag for downstream guards.

## Testing

```bash
# Before fix: fails immediately
python -m kdflow.cli.train_kd_off_policy --help
# ModuleNotFoundError: No module named 'flash_attn'

# After fix: works without flash_attn when packing_samples=False (default)
python -m kdflow.cli.train_kd_off_policy --help
# usage: train_kd_off_policy.py ...
```

Verified on Python 3.13.0, torch 2.9.0+cu128, CUDA 12.8, without flash_attn installed.
