### PR TITLE
fix: defer flash_attn import to avoid hard dependency at startup

### DIFF
--- a/kdflow/models/ring_attn_utils.py
+++ b/kdflow/models/ring_attn_utils.py
@@ -1,7 +1,18 @@
 import torch
 import torch.distributed as dist
-from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
-from flash_attn.utils.distributed import all_gather
+
+
+def _require_flash_attn():
+    """Deferred import — only needed for packing_samples=True."""
+    try:
+        from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
+        from flash_attn.utils.distributed import all_gather as _fa_all_gather
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "flash_attn is required for packing_samples=True. "
+            "Install with: pip install flash_attn --no-build-isolation"
+        ) from e
+    return index_first_axis, pad_input, rearrange, unpad_input, _fa_all_gather
 
 RING_ATTN_GROUP = None
 
@@ -110,7 +121,12 @@ def unpad_and_slice_tensor(sequences, attention_mask, ring_attn_group):
 
     Returns:
         tuple: Processed sequences and related tensors for ring attention
+
+    Note:
+        Requires ``flash_attn`` — only called when ``packing_samples=True``.
     """
+    index_first_axis, pad_input, rearrange, unpad_input, _ = _require_flash_attn()
+
     rolled_sequences = torch.roll(sequences, shifts=-1, dims=1)
     sequences, indices, cu_seqlens, _, _ = unpad_input(sequences.unsqueeze(-1), attention_mask)
     sequences = sequences.transpose(0, 1)  # (1, total_seqs)
@@ -158,9 +174,14 @@ def gather_and_pad_tensor(tensor, ring_attn_group, ring_attn_pad_len, indices, b
 
     Returns:
         Padded tensor
+
+    Note:
+        Requires ``flash_attn`` — only called when ``packing_samples=True``.
     """
+    _, pad_input, _, _, fa_all_gather = _require_flash_attn()
+
     if ring_attn_group is not None:
-        tensor = all_gather(tensor.transpose(0, 1), ring_attn_group).transpose(0, 1)  # (1, total_seqs)
+        tensor = fa_all_gather(tensor.transpose(0, 1), ring_attn_group).transpose(0, 1)  # (1, total_seqs)
         if ring_attn_pad_len > 0:
             tensor = tensor[:, :-ring_attn_pad_len]
     tensor = pad_input(tensor.transpose(0, 1), indices, batch, seqlen).squeeze(-1)  # (batch, seqlen)


### PR DESCRIPTION
## Summary

Resubmission of the `ring_attn_utils.py` change only, as requested in the previous review.

The `sglang_engine.py` change has been dropped — the reviewer correctly pointed out that wrapping sglang imports in `try/except` would silently hide `ImportError` when instantiating `PatchedEngine(...)` without sglang installed, which is worse than the original behaviour.

## What this PR does

`ring_attn_utils.py` imports `flash_attn` at module level, but `flash_attn` is only needed when `packing_samples=True`. Users who do not use sequence packing cannot import `kdflow` (or even run `--help`) in environments where `flash_attn` has no pre-built wheel (e.g. Python 3.13, CUDA 12.8, or torch nightly builds).

**Fix:** wrap `flash_attn` imports in a `_require_flash_attn()` helper that is called lazily at the use-site inside `unpad_and_slice_tensor` and `gather_and_pad_tensor`. The error message guides users to install `flash_attn` only when they actually need it.

## Changes

- `kdflow/models/ring_attn_utils.py` — lazy import only; no behaviour change when `flash_attn` is installed

## Test

Verified that importing `kdflow` without `flash_attn` installed no longer raises `ModuleNotFoundError` unless `packing_samples=True` is actually used.